### PR TITLE
Gdp 959

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,12 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+/env/
+/test_bioclim.zip
+/testFWGS_testfile_multitest
+/testFWGS_testfile_test
+/testFWGS_testfile_vartest
+/testing-requirements.txt
+/testOPenDAP_testfile_test
+/lettucetests.xml
+/owslib.log

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation
 1.) Use of virtualenv and pip is highly recommended. Sample commands to install pyGDP as a virtual env on a mac/unix operating system are given below. Similar commands can be used on windows. 
 
 ```
- git clone https://github.com/USGS-CIDA/pyGDP.git
+git clone https://github.com/USGS-CIDA/pyGDP.git
 virtualenv -p /usr/bin/python2.7 pyGDP/venv
 source pyGDP/venv/bin/activate
 pip install -r pyGDP/requirements.txt

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -r pyGDP/requirements.txt
 pip install -r pyGDP/testing-requirements.txt
 cd pyGDP
 python setup.py install
-lettuce pyGDP/Lettuce_Tests/features/ --tag=-not_working
+lettuce Lettuce_Tests/features/ --tag=-not_working
 ```
 OR
 2.) Install using pip (first install or --upgrade dependencies):

--- a/README.md
+++ b/README.md
@@ -28,15 +28,16 @@ Installation
 ==================
 1.) Use of virtualenv and pip is highly recommended. Sample commands to install pyGDP as a virtual env on a mac/unix operating system are given below. Similar commands can be used on windows. 
 
->> git clone https://github.com/USGS-CIDA/pyGDP.git
->> virtualenv -p /usr/bin/python2.7 pyGDP/venv
->> source pyGDP/venv/bin/activate
->> pip install -r pyGDP/requirements.txt
->> pip install -r pyGDP/testing-requirements.txt
->> cd pyGDP
->> python setup.py install
->> lettuce pyGDP/Lettuce_Tests/features/ --tag=-not_working
-
+```
+ git clone https://github.com/USGS-CIDA/pyGDP.git
+virtualenv -p /usr/bin/python2.7 pyGDP/venv
+source pyGDP/venv/bin/activate
+pip install -r pyGDP/requirements.txt
+pip install -r pyGDP/testing-requirements.txt
+cd pyGDP
+python setup.py install
+lettuce pyGDP/Lettuce_Tests/features/ --tag=-not_working
+```
 OR
 2.) Install using pip (first install or --upgrade dependencies):
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,3 +1,6 @@
+The services by default use publically available services. The QA and dev services can be used instead
+by setting the environment variable PYGDP_TIER to either 'testing' or 'development'.
+
 pyGDP_client.py
 ===============
 

--- a/pygdp/namespaces.py
+++ b/pygdp/namespaces.py
@@ -26,7 +26,7 @@ def get_URLs(environ_name):
         
     if environ_name == 'testing':
         
-      urls        = {  'WFS_URL'	        :	'http://cida-test.er.usgs.gov/gdp/geoserver/wfs',
+        urls        = {  'WFS_URL'	        :	'http://cida-test.er.usgs.gov/gdp/geoserver/wfs',
                       'upload_URL'	        :	'http://cida-test.er.usgs.gov/gdp/geoserver',
                       'WPS_URL'	        :	'http://cida-test.er.usgs.gov/gdp/process/WebProcessingService',
                       'WPS_Service'	        :	'http://cida-test.er.usgs.gov/gdp/utility/WebProcessingService',
@@ -43,7 +43,7 @@ def get_URLs(environ_name):
                        }
     return urls
 
-urls=get_URLs(environ_name = 'production')
+urls=get_URLs(environ_name = os.environ.get('PYGDP_SDL', 'production'))
 
 WFS_URL    = urls['WFS_URL']
 upload_URL = urls['upload_URL']

--- a/pygdp/namespaces.py
+++ b/pygdp/namespaces.py
@@ -43,7 +43,7 @@ def get_URLs(environ_name):
                        }
     return urls
 
-urls=get_URLs(environ_name = os.environ.get('PYGDP_SDL', 'production'))
+urls=get_URLs(environ_name = os.environ.get('PYGDP_TIER', 'production'))
 
 WFS_URL    = urls['WFS_URL']
 upload_URL = urls['upload_URL']


### PR DESCRIPTION
Using an environment variable, PYGDP_TIER, to allow the user of the pyGDP package to define what tier services should be used. If not set, defaults to production. Otherwise can be set to 'testing' or 'development'