### PR TITLE
Support version 0.9.x of OWSLib

### DIFF
--- a/Lettuce_Tests/features/Test_CSW.py
+++ b/Lettuce_Tests/features/Test_CSW.py
@@ -3,9 +3,9 @@ from nose.tools import assert_equal, assert_true
 import pyGDP
 import warnings
 
-@step(r'I define the keyword as "(.*)"')
-def define_keyword(step, keyword):
-    world.my_keyword = keyword
+@step(r'I define the keyword as "prism climate group"')
+def define_keyword(step, keyword='prism climate group'):
+    world.my_keyword = [keyword]
 
 @step(r'I invoke the pyGDP.getDataSetURI method')
 def invoke_getDataSetURI(step):
@@ -26,7 +26,7 @@ def create_web_processing_object():
 
 @step(r'I am not defining any keywords')
 def undefine_keyword(step):
-    world.my_keyword == ''
+    world.my_keyword == None
 
 @step(r'I see anywhere between 1 and 1000 datasets')
 def true_within_range(step):

--- a/Lettuce_Tests/features/Test_GeoServer_Interactivity.py
+++ b/Lettuce_Tests/features/Test_GeoServer_Interactivity.py
@@ -28,13 +28,13 @@ def define_the_conus(step):
 
 @step(r'I use the getAttributes method and I get a list of those attributes')
 def get_the_attributes(step):
-      test_pyGDP = create_web_processing_object()
-      world.attributes = test_pyGDP.getAttributes(world.shapefile)
+    test_pyGDP = create_web_processing_object()
+    world.attributes = test_pyGDP.getAttributes(world.shapefile)
 
 @step(r'I should see an expected number of attributes')
 def check_the_attributes(step):
-      assert_equal(len(world.attributes), 10)
-      assert('STATE' in world.attributes)
+    assert_equal(len(world.attributes), 10)
+    assert('STATE' in world.attributes)
 
 @step(r'I know that one of those attributes is "STATE"')
 def that_attribute_is_state(step):
@@ -72,4 +72,3 @@ def every_of_the_conus(step):
 @step(r'I am given multiple expected outputs from Feature Collection')
 def all_feature_collection(step):
     assert_not_equal(len(world.feature_collection.query.filters), 0)
-    

--- a/pyGDP.py
+++ b/pyGDP.py
@@ -154,7 +154,14 @@ class pyGDPwebProcessing():
             ch.setLevel(logging.INFO)
         return webdata_handle.getDataUnits(dataSetURI, verbose)
     
-    def getDataSetURI(self, anyText='',CSWURL=CSWURL,BBox=None):
+    def getDataSetURI(self, anyText=None, CSWURL=CSWURL, BBox=None):
+        """
+        Searches a given CSW server and returns metadata content for the datasets found.
+        
+        :param anyText: keywords to be passed to CSW get records
+        :type anyText: list or None
+        
+        """
         return  webdata_handle.getDataSetURI(anyText, CSWURL, BBox)
 
     def getTimeRange(self, dataSetURI, varID, verbose=False):

--- a/pygdp/shapefile_value_handle.py
+++ b/pygdp/shapefile_value_handle.py
@@ -1,6 +1,7 @@
 #The functions in this file exist to WFS requests to get the various values that exist for
 #shapefiles on the GDP. These include the shapefiles themselves, the attributes of those
 #shapefiles, and the values of those attributes.
+from io import BytesIO
 from owslib.wfs import WebFeatureService
 from owslib.etree import etree
 from pygdp.namespaces import upload_URL, WPS_URL, WPS_Service, CSWURL #WFS_URL, 
@@ -25,8 +26,9 @@ def getAttributes(shapefile, WFS_URL):
     """
     wfs = WebFeatureService(WFS_URL, version='1.1.0')
     feature = wfs.getfeature(typename=shapefile, maxfeatures=1, propertyname=None)
-    gml = etree.parse(feature)
-    gml_root=gml.getroot()
+    content = BytesIO(feature.read())
+    gml = etree.parse(content)
+    gml_root = gml.getroot()
     name_spaces = gml_root.nsmap
     
     attributes = []

--- a/pygdp/webdata_handle.py
+++ b/pygdp/webdata_handle.py
@@ -17,7 +17,7 @@ def getDataSetURI(anyText, CSWURL, BBox):
 
                             csw = CatalogueServiceWeb(CSWURL, skip_caps=True)
                             #Works with owslib version 0.8.6.
-                            csw.getrecords(keywords=[anyText], outputschema='http://www.isotc211.org/2005/gmd', esn='full', maxrecords=100)
+                            csw.getrecords(keywords=anyText, outputschema='http://www.isotc211.org/2005/gmd', esn='full', maxrecords=100)
                             dataSetURIs = [['title','abstract',['urls']]]
                             for rec in csw.records:
                                     title=csw.records[rec].identification.title

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-OWSLib==0.8.10
+OWSLib>=0.9.2
 lxml==3.3.5
 python-dateutil==2.2

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,4 +1,4 @@
-OWSLib==0.8.10
+OWSLib>=0.9.2
 lxml==3.3.5
 python-dateutil==2.2
 lettuce==0.2.19


### PR DESCRIPTION
Changes to support current versions of OWSLib. 

During this work a bug was found in version 0.9.1 of OWSLib; the bug has since been fixed, but a new version hasn't been released. Requirements reflect this with the caveat that there isn't a released version over 0.9.1 right now. I'd recommend merging these changes into master (or another branch) and cut a release when a new version of OWSLib is available.