### PR TITLE
silence overly detailed log messages when a user doesn't need them... issue #125

### DIFF
--- a/pyGDP.py
+++ b/pyGDP.py
@@ -31,6 +31,17 @@ from pygdp.namespaces import DRAW_NAMESPACE, SMPL_NAMESPACE, UPLD_NAMESPACE
 from pygdp.namespaces import URL_timeout, WPS_attempts
 from pygdp.namespaces import namespaces
 
+
+try:
+    from config import PYGDP_INFO_LOGGING
+except ImportError:
+    PYGDP_INFO_LOGGING = False
+if not PYGDP_INFO_LOGGING:
+    logging.disable(logging.INFO)  # silence all log messages at the INFO level and below
+else:
+    logging.disable(logging.NOTSET)
+
+
 #Get OWSLib Logger
 logger = logging.getLogger('owslib')
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Pass at #125.

This should silence `DEBUG` and `INFO` level mesages for the user, while still presenting them with messages at WARNING and higher.

There's an option for a `config.py` where settings like this can be defined, but if it isn't, an value is provided.