### PR TITLE
WIP :: DO NOT MERGE YET :: update README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     env: TEST_TARGET=default
   - python: 3.6
     env: TEST_TARGET=default
+  # no lettuce on Python 3
   allow_failures:
   - python: 3.6
     env: TEST_TARGET=default

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ pyGDP has the following algorithms:
 **Before using the Geo Data Portal via Python, please read the scalability guidelines.**  
 https://my.usgs.gov/confluence/display/GeoDataPortal/Geo+Data+Portal+Scalability+Guidelines
 
-Additional documentation can be found at the Geo Data Portal wiki. 
+Additional documentation can be found at the Geo Data Portal wiki.
 https://my.usgs.gov/confluence/pages/viewpage.action?pageId=250937417
 
 Dependencies
 =================
 
-pyGDP request owslib and lxml.etree (which, in turn, uses libxml2 and libxslt)
+pyGDP request OWSLib and lxml (which, in turn, uses libxml2 and libxslt).
 
 Usage
 =================
@@ -29,29 +29,22 @@ You can find example usages and scripts in the examples folder.
 
 Installation
 ==================
-1.) Use of virtualenv and pip is highly recommended. Sample commands to install pyGDP as a virtual env on a mac/unix operating system are given below. Similar commands can be used on windows. 
+Use of virtualenv and pip is highly recommended.
+Sample commands to install pyGDP as a virtual env on a mac/unix operating system are given below.
+Similar commands can be used on windows.
 
 ```
 git clone https://github.com/USGS-CIDA/pyGDP.git
 virtualenv -p /usr/bin/python2.7 pyGDP/venv
 source pyGDP/venv/bin/activate
-pip install -r pyGDP/requirements.txt
-pip install -r pyGDP/testing-requirements.txt
 cd pyGDP
-python setup.py install
+pip install .
 lettuce Lettuce_Tests/features/ --tag=-not_working
 ```
-Anaconda and other package managers can be used, but pyGDP must be installed from source.
 
-For pip, do: 
-`pip install owslib==0.13.0`
+Anaconda and other package managers can be used.
 
-For Anaconda, do:
-`conda install -c conda-forge owslib=0.13.0`
-
-Then download the latest release of pyGDP here: [https://github.com/USGS-CIDA/pyGDP/releases](https://github.com/USGS-CIDA/pyGDP/releases), extract its contents, and run:  
-`python setup.py install`  
-with the python environment you installed owslib into active.
+`conda install -c conda-forge pygdp`
 
 Support
 =================
@@ -66,14 +59,17 @@ Thanks
 
 Disclaimer
 ----------
-This software is in the public domain because it contains materials that originally came from the U.S. Geological Survey, an agency of the United States Department of Interior. For more information, see the official USGS copyright policy at [http://www.usgs.gov/visual-id/credit_usgs.html#copyright](http://www.usgs.gov/visual-id/credit_usgs.html#copyright)
+This software is in the public domain because it contains materials that originally came from the U.S. Geological Survey,
+an agency of the United States Department of Interior.
+For more information, see the official USGS copyright policy at [http://www.usgs.gov/visual-id/credit_usgs.html#copyright](http://www.usgs.gov/visual-id/credit_usgs.html#copyright).
 
 
-Although this software program has been used by the U.S. Geological Survey (USGS), no warranty, expressed or implied, is made by the USGS or the U.S. Government as to the accuracy and functioning of the program and related program material nor shall the fact of distribution constitute any such warranty, and no responsibility is assumed by the USGS in connection therewith.
+Although this software program has been used by the U.S. Geological Survey (USGS),
+no warranty, expressed or implied,
+is made by the USGS or the U.S. Government as to the accuracy and functioning of the program and related program material nor shall the fact of distribution constitute any such warranty,
+and no responsibility is assumed by the USGS in connection therewith.
 
 This software is provided "AS IS."
 
 
- [
-    ![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)
-  ](http://creativecommons.org/publicdomain/zero/1.0/)
+ [![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
I am working on a package re-organization and bringing `setup.py` up to speed with latest best practices for easier installation using up-to-date dependencies and wheels whenever possible.

However, there are no wheels for `lxml 3.3.5`. So I am looking into fixing the errors we get when upgrading `lxml` or getting rid of it altogether and use `OWSLib` `etree` wrapper.